### PR TITLE
 Simplify recipe for CB3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,25 +10,40 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256sum }}
+  patches:
+    - 0001-Add-compiler-flag-for-realigning-stack.patch  # [win32 and py27]
 
 build:
   number: 0
-  skip: True  # [win and py27]
-  features:
-    - vc14  # [win and py35]
-    - vc14  # [win and py36]
   detect_binary_files_with_prefix: False
 
 requirements:
-  build:
+  host:
     - python
     - setuptools
-    - numpy >=1.7
+    - numpy
     - cython >=0.22,!=0.25.1
+    # The VS2008 build of PyStan fails with:
+    # fatal error C1060: compiler is out of heap space
+    # so we use the m2w64-toolchain here
+    - libpython              # [win and py27]
+    - m2w64-toolchain        # [win and py27]
+
+  build:
+    - m2-patch               # [win and py27]
+    - {{ compiler('c') }}    # [not (win and py27)]
+    - {{ compiler('cxx') }}  # [not (win and py27)]
 
   run:
+    - {{ pin_compatible('numpy') }}
+    # http://pystan.readthedocs.io/en/latest/windows.html
+    # PyStan requires a C++ compiler for building models. For
+    # full support of vectorized functions, gcc is recommended.
+    - libpython              # [win]
+    - m2w64-toolchain        # [win]
+    - {{ compiler('c') }}    # [not win]
+    - {{ compiler('cxx') }}  # [not win]
     - python
-    - numpy >=1.7
     - cython >=0.22,!=0.25.1
     - matplotlib
 


### PR DESCRIPTION
Compilers are in run-time deps because:
```
PyStan also requires that a C++ compiler be available to Python during installation and at runtime.
```